### PR TITLE
Fix typo preventing correct oauth session creation

### DIFF
--- a/stashy/client.py
+++ b/stashy/client.py
@@ -76,7 +76,7 @@ class StashClient(object):
             rsa_key=oauth['key_cert'],
             signature_method=SIGNATURE_RSA,
             resource_owner_key=oauth['access_token'],
-            resource_owner_secret=outh['access_token_secret']
+            resource_owner_secret=oauth['access_token_secret']
         )
         self._session.auth = oauth
 


### PR DESCRIPTION
- resource_owner_secret was being set from 'outh' dict instead of 'oauth'.